### PR TITLE
fix: embedded types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2022-01-27
+
+### Fixed
+
+- Allow embedded types
+
 ## [2.0.0] - 2022-01-21
 
 ### BREAKING

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@genially/mongoose-mimic",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@genially/mongoose-mimic",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "faker": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@genially/mongoose-mimic",
   "description": "mongoose-mimic is a small (but powerful) Node.js library to generate test data for Mongoose using only the schema definition",
   "private": false,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "src/index.js",
   "files": [
     "src"

--- a/src/extractSchemaPaths.js
+++ b/src/extractSchemaPaths.js
@@ -19,6 +19,7 @@
  *  min: Number <Minimum value if has minimum>,
  *  isArray: Boolean <if the path is an array>
  *  arrayDefinition: Object <Path Definition Object for array element>
+ *  embeddedDefinition: Object <Path Definition Object for embedded element>
  *  ref: String <Referenced object if has reference>
  * }
  */
@@ -45,6 +46,10 @@ const generateDefinition = (path) => {
         definition.min = val.min;
       }
     });
+  }
+
+  if (path.instance.toLowerCase() === 'embedded') {
+    definition.embeddedDefinition = extractSchemaPaths(path.schema);
   }
 
   if (path.instance.toLowerCase() === 'array') {

--- a/src/generateRandomDoc.js
+++ b/src/generateRandomDoc.js
@@ -101,6 +101,11 @@ const generateRandomDoc = (
 
     const type = definition.type.toLowerCase();
 
+    if (type === 'embedded') {
+      generatedDoc[field] = generateRandomDoc(definition.embeddedDefinition, opts);
+      return;
+    }
+
     if (type === 'array') {
       generatedDoc[field] = generateRandomArray(
         field,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -55,6 +55,16 @@ describe('mongoose-mimic', () => {
         type: Date,
         default: Date.now,
       },
+      organization: {
+        type: {
+          id: { type: String },
+          name: { type: String },
+          created_at: { type: Date },
+          phones: {
+            type: [Number],
+          },
+        },
+      },
     });
 
     model = mongoose.model('Student', schemaDefinition);
@@ -81,6 +91,10 @@ describe('mongoose-mimic', () => {
       expect(randomObject.phones).toBeArray();
       expect(randomObject.parent).toBeString();
       expect(isObjectId(randomObject.parent)).toBeTrue();
+      expect(randomObject.organization.id).toBeString();
+      expect(randomObject.organization.name).toBeString();
+      expect(randomObject.organization.created_at).toBeDate();
+      expect(randomObject.organization.phones[0]).toBeNumber();
       expect(randomObject._id).toBeString();
       expect(isObjectId(randomObject._id)).toBeTrue();
       expect(randomObject.__v).toBeNumber();


### PR DESCRIPTION
It seems that mongoose v6 is using `instance: 'Embedded'` when it sees somthing like: 

```
organization: {
        type: {
          id: { type: String },
          name: { type: String },
          created_at: { type: Date },
          phones: {
            type: [Number],
          },
        },
      },
```

In mongoose v5 it was `instance: 'Mixed'`.