### PR TITLE
fix: 🐛 compatilibity with generation of objectId to work with mongoose >= v7

### DIFF
--- a/src/generators/generateObjectId.js
+++ b/src/generators/generateObjectId.js
@@ -3,4 +3,4 @@ const mongoose = require('mongoose');
 /**
  * Generates a random ObjectId
  */
-module.exports = () => mongoose.Types.ObjectId().toString();
+module.exports = () => new mongoose.Types.ObjectId().toString();


### PR DESCRIPTION
This PR solves the problem when mongoose-mimic tries to generate objectIds with mongoose >= v7